### PR TITLE
Add "client auth" to server profile usages

### DIFF
--- a/Kubernetes Tutorials 02 - Generate Certificate for ETCD.md
+++ b/Kubernetes Tutorials 02 - Generate Certificate for ETCD.md
@@ -216,7 +216,8 @@ Modified ca-config.json
                 "usages": [
                     "signing",
                     "key encipherment",
-                    "server auth"
+                    "server auth",
+                    "client auth"
                 ]
             },
             "client": {


### PR DESCRIPTION
I used the process to generate the related stuff and the tested the certificates with 3 etcd instances. I saw an error in etcd logs saying:

> tls: failed to verify client certificate: x509: certificate specifies an incompatible key usage

which can be fixed by the change proposed in this pull request.